### PR TITLE
Update validation to handle boolean errors

### DIFF
--- a/sliceline/slicefinder.py
+++ b/sliceline/slicefinder.py
@@ -140,7 +140,7 @@ class Slicefinder(BaseEstimator, TransformerMixin):
         self._check_params()
 
         # Check that X and e have correct shape
-        X_array, errors = check_X_e(X, errors)
+        X_array, errors = check_X_e(X, errors, y_numeric=True)
 
         self._check_feature_names(X, reset=True)
 

--- a/sliceline/validation.py
+++ b/sliceline/validation.py
@@ -805,7 +805,7 @@ def _check_y(y, multi_output=False, y_numeric=False, estimator=None):
         y = column_or_1d(y, warn=True)
         _assert_all_finite(y, input_name="y", estimator_name=estimator_name)
         _ensure_no_complex_data(y)
-    if y_numeric and y.dtype.kind == "O":
+    if y_numeric and y.dtype.kind in ("O", "b"):
         y = y.astype(np.float64)
 
     return y

--- a/sliceline/validation.py
+++ b/sliceline/validation.py
@@ -806,7 +806,7 @@ def _check_y(y, multi_output=False, y_numeric=False, estimator=None):
         _assert_all_finite(y, input_name="y", estimator_name=estimator_name)
         _ensure_no_complex_data(y)
     if y_numeric and y.dtype.kind in ("O", "b"):
-        y = y.astype(np.float64)
+        y = y.astype(np.float32)
 
     return y
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,7 @@ def basic_test_data():
 @pytest.fixture
 def experiments():
     """Implement several end-to-end examples with the expected outputs regarding the inputs."""
-    # Experiment 1: basic case
+    # Experiment 1: basic case with boolean errors
     np.random.seed(1)
     n_small = 10
     X_1 = np.array(
@@ -121,7 +121,7 @@ def experiments():
             np.random.randint(1, 4, size=2 * n_small),
         ]
     ).T
-    errors_1 = np.array([1] * n_small + [0] * n_small)
+    errors_1 = np.array([True] * n_small + [False] * n_small)
     expected_top_slices_1 = np.array([[1, 1, None], [None, 1, 2], [1, None, 2]])
     experiment_1 = Experiment(X_1, errors_1, expected_top_slices_1)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,7 +139,7 @@ def experiments():
     ).T
     errors_2 = np.array([1] * n_small + [0] * n_small)
     expected_top_slices_2 = np.array(
-        [[None, 1.0, None, None, 1.0, None], [None, None, 4.0, None, 1.0, None]]
+        [[None, 1, None, None, 1, None], [None, None, 4, None, 1, None]]
     )
     experiment_2 = Experiment(X_2, errors_2, expected_top_slices_2)
 


### PR DESCRIPTION
This PR updates the validation of the `errors` array passed to the `fit` method. In case of boolean `errors`, the `errors` is typed as `float`.

Resolves https://github.com/DataDome/sliceline/issues/34