### PR TITLE
fixing falsely named rmse to mse

### DIFF
--- a/notebooks/2. Implementing Sliceline on California housing dataset.ipynb
+++ b/notebooks/2. Implementing Sliceline on California housing dataset.ipynb
@@ -921,14 +921,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Model RMSE on:\n",
+      "Model MSE on:\n",
       "- the full dataset (20640 houses): 0.1641313869461246\n",
       "- the selected slice (1756 houses): 0.3706251665488993\n"
      ]
     }
    ],
    "source": [
-    "from sklearn.metrics import mean_squared_error as rmse\n",
+    "from sklearn.metrics import mean_squared_error as mse\n",
     "\n",
     "# select one slice\n",
     "slice_index = 0\n",
@@ -947,11 +947,11 @@
     "# get slice element indices\n",
     "indices = X_trans.query(condition).index\n",
     "\n",
-    "print(\"Model RMSE on:\")\n",
-    "print(f\"- the full dataset ({X.shape[0]} houses):\", rmse(y, y_pred))\n",
+    "print(\"Model MSE on:\")\n",
+    "print(f\"- the full dataset ({X.shape[0]} houses):\", mse(y, y_pred))\n",
     "print(\n",
     "    f\"- the selected slice ({len(indices)} houses):\",\n",
-    "    rmse(y.iloc[indices], y_pred[indices]),\n",
+    "    mse(y.iloc[indices], y_pred[indices]),\n",
     ")"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sliceline"
-version = "0.3.0"
+version = "0.3.1"
 description = "Fast slice finding for Machine Learning model debugging."
 readme = "README.rst"
 license = "BSD-3-Clause"


### PR DESCRIPTION
In the previous code the mse was called rmse (also in the print statements): from sklearn.metrics import mean_squared_error as rmse I renamed everything to mse.