### PR TITLE
chore: migrate Node-20 actions to Node-24-compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
     - name: Install pypa/build
@@ -24,7 +24,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: python-package-distributions
         path: dist/
@@ -43,7 +43,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-package-distributions
         path: dist/
@@ -64,7 +64,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
     - name: Install pypa/build
@@ -24,7 +24,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: python-package-distributions
         path: dist/
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/


### PR DESCRIPTION
Automated migration bumping Node-20 GitHub Actions to Node-24-compatible releases ahead of GitHub's 2026-06-02 forced-runtime cutover.

Changes in this PR:

- `.github/workflows/release.yml`: `actions/checkout@v4` → `actions/checkout@v6`
- `.github/workflows/release.yml`: `actions/setup-python@v5` → `actions/setup-python@v6`
- `.github/workflows/release.yml`: `actions/upload-artifact@v4` → `actions/upload-artifact@v7`
- `.github/workflows/release.yml`: `actions/download-artifact@v4` → `actions/download-artifact@v8`
- `.github/workflows/release.yml`: `actions/download-artifact@v4` → `actions/download-artifact@v8`
- `.github/workflows/test-release.yml`: `actions/checkout@v4` → `actions/checkout@v6`
- `.github/workflows/test-release.yml`: `actions/setup-python@v5` → `actions/setup-python@v6`
- `.github/workflows/test-release.yml`: `actions/upload-artifact@v4` → `actions/upload-artifact@v7`
- `.github/workflows/test-release.yml`: `actions/download-artifact@v4` → `actions/download-artifact@v8`

## Breaking-change analysis

### `.github/workflows/release.yml:11` `actions/checkout` — risk: :green_circle: **NONE**

No breaking-change indicators in release notes; workflow's `with:` keys not mentioned.

Release notes: https://github.com/actions/checkout/compare/v4...v6

### `.github/workflows/release.yml:15` `actions/setup-python` — risk: :yellow_circle: **LOW**

Breaking-change indicators found in release notes, but none of the workflow's `with:` keys appear to be affected.

Release notes: https://github.com/actions/setup-python/compare/v5...v6

### `.github/workflows/release.yml:27` `actions/upload-artifact` — risk: :yellow_circle: **LOW**

Breaking-change indicators found in release notes, but none of the workflow's `with:` keys appear to be affected.

Release notes: https://github.com/actions/upload-artifact/compare/v4...v7

### `.github/workflows/release.yml:46` `actions/download-artifact` — risk: :red_circle: **HIGH**

Breaking-change indicators found in release notes and workflow uses affected key(s): 'path'.

Release notes: https://github.com/actions/download-artifact/compare/v4...v8

- * BREAKING fix: inconsistent path behavior for single artifact downloads by ID by @GrantBirki in https://github.com/actions/download-artifact/pull/416

### `.github/workflows/release.yml:67` `actions/download-artifact` — risk: :red_circle: **HIGH**

Breaking-change indicators found in release notes and workflow uses affected key(s): 'path'.

Release notes: https://github.com/actions/download-artifact/compare/v4...v8

- * BREAKING fix: inconsistent path behavior for single artifact downloads by ID by @GrantBirki in https://github.com/actions/download-artifact/pull/416

### `.github/workflows/test-release.yml:11` `actions/checkout` — risk: :green_circle: **NONE**

No breaking-change indicators in release notes; workflow's `with:` keys not mentioned.

Release notes: https://github.com/actions/checkout/compare/v4...v6

### `.github/workflows/test-release.yml:15` `actions/setup-python` — risk: :yellow_circle: **LOW**

Breaking-change indicators found in release notes, but none of the workflow's `with:` keys appear to be affected.

Release notes: https://github.com/actions/setup-python/compare/v5...v6

### `.github/workflows/test-release.yml:27` `actions/upload-artifact` — risk: :yellow_circle: **LOW**

Breaking-change indicators found in release notes, but none of the workflow's `with:` keys appear to be affected.

Release notes: https://github.com/actions/upload-artifact/compare/v4...v7

### `.github/workflows/test-release.yml:49` `actions/download-artifact` — risk: :red_circle: **HIGH**

Breaking-change indicators found in release notes and workflow uses affected key(s): 'path'.

Release notes: https://github.com/actions/download-artifact/compare/v4...v8

- * BREAKING fix: inconsistent path behavior for single artifact downloads by ID by @GrantBirki in https://github.com/actions/download-artifact/pull/416

