### PR TITLE
chore(INFRA-13401): upgrade GitHub Actions to support Node.js 24

### DIFF
--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -16,9 +16,9 @@ jobs:
         numba: [true, false]
     name: Python ${{ matrix.python-version }} (Numba=${{ matrix.numba }})
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install LLVM for Numba optimization


### PR DESCRIPTION
Automated migration bumping Node-20 GitHub Actions to Node-24-compatible releases ahead of GitHub's 2026-06-02 forced-runtime cutover.

Changes in this PR:

- `.github/workflows/push-pull.yml`: `actions/checkout@v3` → `actions/checkout@v6`
- `.github/workflows/push-pull.yml`: `actions/setup-python@v4` → `actions/setup-python@v6`